### PR TITLE
[codex] add NWB ingestion scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Added NWB-facing data models for recording summaries, electrical series references, and canonical sorted spike times.
+- Added initial NWB loading utilities for inspecting local `.nwb` files, listing electrical series, checking for a units table, and reading electrical data chunks.
+- Added spike extraction utilities to load spike times from an NWB `units` table, validate the resulting container, and flatten spike times across units.
+- Added a small inspection script at `scripts/inspect_nwb.py` for manually summarizing an NWB file from the command line.
+- Added optional `nwb` dependencies in `pyproject.toml` via `pynwb`.
+- Added initial tests for spike container validation and a synthetic NWB round-trip covering raw traces plus sorted units.

--- a/docs/nwb_ingestion.md
+++ b/docs/nwb_ingestion.md
@@ -1,0 +1,140 @@
+# NWB Ingestion Layer
+
+## Purpose
+
+This document describes the current NWB-facing ingestion layer for
+`brain_organoid_criticality` and the next steps for evolving it into a fuller
+upstream subsystem.
+
+The goal of this layer is to give the project a clean entry point for working
+with NWB-backed electrophysiology datasets, including DANDI-hosted in vivo
+recordings, while keeping downstream criticality analyses independent of PyNWB
+internals.
+
+## Current Scope
+
+The current implementation supports local NWB files and provides:
+
+- metadata-first inspection of an NWB file
+- discovery of available `ElectricalSeries` objects
+- chunked reading of electrical trace data by sample index
+- detection of whether an NWB `units` table is present
+- extraction of spike times from the NWB `units` table into a package-level
+  canonical container
+
+This is intentionally a thin first slice. It is designed to support questions
+such as:
+
+- Does this file contain raw electrical traces?
+- Does this file already contain sorted units?
+- What is the approximate sampling rate, duration, and channel count?
+- Can downstream analyses consume archived spike times without depending on
+  `pynwb` directly?
+
+## Module Boundaries
+
+The current boundary between modules is:
+
+- `loaders.py`
+  Reads NWB files using PyNWB and exposes normalized recording-level summaries
+  and electrical-series references.
+- `spikes.py`
+  Converts NWB `units` tables into the project-level `SortedSpikes` container
+  and validates spike-time structure.
+- `models.py`
+  Defines small dataclasses that downstream code can depend on without needing
+  to import PyNWB.
+- `avalanches.py`
+  Remains downstream analysis code and should consume standardized spike times,
+  not raw NWB containers.
+
+Future work should keep this boundary intact. Raw NWB access belongs in the
+loader layer. Spike-sorting pipeline integration belongs in a future
+`sorting.py`. Criticality analyses should operate on the normalized outputs of
+those layers.
+
+## Current Public API
+
+The initial NWB-related API consists of:
+
+- `inspect_nwb(path)`
+- `list_electrical_series(path)`
+- `get_electrical_series_ref(path, series_name=None)`
+- `read_electrical_series_chunk(path, series_name=None, start=0, stop=None)`
+- `has_units_table(path)`
+- `load_units_from_nwb(path)`
+- `flatten_spike_times(sorted_spikes)`
+- `validate_sorted_spikes(sorted_spikes)`
+
+The canonical model types are:
+
+- `RecordingSummary`
+- `ElectricalSeriesRef`
+- `SortedSpikes`
+
+## Design Intent
+
+The important design choice in this layer is that public package code should
+not pass around raw `NWBFile` objects. Instead:
+
+1. `loaders.py` uses PyNWB internally.
+2. The rest of the package depends on small, stable dataclasses and NumPy
+   arrays.
+3. Downstream analysis modules remain insulated from file-format details.
+
+This keeps the project adaptable as additional loaders, manifest formats, and
+sorting backends are added.
+
+## What This Layer Does Not Do Yet
+
+The current implementation does not yet provide:
+
+- DANDI API integration or remote asset access
+- manifest-driven dataset selection
+- generalized support for multiple NWB acquisition layouts
+- a `sorting.py` layer for running or importing external spike-sorting results
+- richer extraction of subject, session, probe, or channel metadata
+- benchmark notebooks on real public datasets
+
+Those are expected follow-on tasks rather than omissions in the current scope.
+
+## Tests
+
+Current tests cover:
+
+- spike-container flattening and validation
+- a synthetic NWB file with both an `ElectricalSeries` acquisition and a
+  `units` table
+- inspection, chunked trace reads, and unit extraction from that synthetic file
+
+The focused test command used for this layer was:
+
+```bash
+HOME=/Users/asgnxt/brain_organoid_criticality PYNWB_NO_CACHE_DIR=1 .venv/bin/python -m pytest tests
+```
+
+## Environment Notes
+
+PyNWB initializes a cache directory during import. In constrained or sandboxed
+environments, that cache path may need to be redirected away from the default
+user cache location.
+
+For local development in this repository, using a repo-local `HOME` together
+with `PYNWB_NO_CACHE_DIR=1` was sufficient to run the current test suite in the
+provided sandbox.
+
+## Immediate Follow-up TODOs
+
+The next tasks for this layer should be:
+
+- add DANDI-aware dataset manifests that record dandiset ID, version, and asset
+  path
+- support remote DANDI asset resolution in addition to local `.nwb` paths
+- expand metadata extraction for subjects, probes, channels, and session-level
+  provenance
+- handle multiple electrical series more explicitly, including clearer
+  selection logic
+- add tests covering units-only files, raw-only files, and multi-series files
+- add a future `sorting.py` adapter layer for external spike-sorting pipelines
+- validate this API against one real DANDI dataset such as Allen Visual Coding
+  or OpenScope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,10 @@ classifiers = [
   "Intended Audience :: Science/Research",
   "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
-dependencies = []
+dependencies = ["numpy"]
+
+[project.optional-dependencies]
+nwb = ["pynwb"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/inspect_nwb.py
+++ b/scripts/inspect_nwb.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import argparse
+
+from brain_organoid_criticality.loaders import inspect_nwb, list_electrical_series
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect an NWB file")
+    parser.add_argument("path", help="Path to an NWB file")
+    args = parser.parse_args()
+
+    summary = inspect_nwb(args.path)
+    print(summary)
+
+    electrical_series = list_electrical_series(args.path)
+    if electrical_series:
+        print("\nElectrical series:")
+        for ref in electrical_series:
+            print(ref)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/brain_organoid_criticality/__init__.py
+++ b/src/brain_organoid_criticality/__init__.py
@@ -1,1 +1,30 @@
+from .avalanches import bin_spike_times
+from .io import validate_path
+from .loaders import (
+    get_electrical_series_ref,
+    has_units_table,
+    inspect_nwb,
+    list_electrical_series,
+    read_electrical_series_chunk,
+)
+from .models import ElectricalSeriesRef, RecordingSummary, SortedSpikes
+from .spikes import flatten_spike_times, load_units_from_nwb, validate_sorted_spikes
+
 __version__ = "0.1.0"
+
+__all__ = [
+    "ElectricalSeriesRef",
+    "RecordingSummary",
+    "SortedSpikes",
+    "__version__",
+    "bin_spike_times",
+    "flatten_spike_times",
+    "get_electrical_series_ref",
+    "has_units_table",
+    "inspect_nwb",
+    "list_electrical_series",
+    "load_units_from_nwb",
+    "read_electrical_series_chunk",
+    "validate_path",
+    "validate_sorted_spikes",
+]

--- a/src/brain_organoid_criticality/loaders.py
+++ b/src/brain_organoid_criticality/loaders.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .io import validate_path
+from .models import ElectricalSeriesRef, RecordingSummary
+
+
+def inspect_nwb(path: str | Path) -> RecordingSummary:
+    """
+    Inspect an NWB file and return a normalized summary.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to an NWB file on disk.
+
+    Returns
+    -------
+    RecordingSummary
+        Summary of the recording contents and metadata.
+    """
+    source_path = validate_path(path)
+
+    with _open_nwb(source_path) as nwbfile:
+        electrical_series = _collect_electrical_series_refs(nwbfile, source_path)
+        subject = getattr(nwbfile, "subject", None)
+        subject_id = getattr(subject, "subject_id", None) if subject is not None else None
+        sampling_rate_hz = electrical_series[0].sampling_rate_hz if electrical_series else None
+        n_channels = electrical_series[0].n_channels if electrical_series else None
+
+        return RecordingSummary(
+            source_path=source_path,
+            session_id=getattr(nwbfile, "session_id", None),
+            subject_id=subject_id,
+            experiment_description=getattr(nwbfile, "experiment_description", None),
+            identifier=getattr(nwbfile, "identifier", None),
+            sampling_rate_hz=sampling_rate_hz,
+            duration_s=_estimate_duration_seconds(nwbfile, electrical_series),
+            n_channels=n_channels,
+            has_raw_electrical_series=bool(electrical_series),
+            has_units=getattr(nwbfile, "units", None) is not None,
+            acquisition_names=sorted(nwbfile.acquisition.keys()),
+            processing_modules=sorted(nwbfile.processing.keys()),
+            metadata={
+                "electrical_series_names": [ref.series_name for ref in electrical_series],
+                "institution": getattr(nwbfile, "institution", None),
+                "lab": getattr(nwbfile, "lab", None),
+                "session_description": getattr(nwbfile, "session_description", None),
+            },
+        )
+
+
+def list_electrical_series(path: str | Path) -> list[ElectricalSeriesRef]:
+    """
+    List electrical series available in an NWB file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to an NWB file on disk.
+
+    Returns
+    -------
+    list of ElectricalSeriesRef
+        Metadata-only references to electrical recordings.
+    """
+    source_path = validate_path(path)
+
+    with _open_nwb(source_path) as nwbfile:
+        return _collect_electrical_series_refs(nwbfile, source_path)
+
+
+def get_electrical_series_ref(
+    path: str | Path,
+    series_name: str | None = None,
+) -> ElectricalSeriesRef:
+    """
+    Select one electrical series for downstream processing.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to an NWB file on disk.
+    series_name : str, optional
+        Name of the electrical series to select. If omitted, exactly one
+        electrical series must be present.
+
+    Returns
+    -------
+    ElectricalSeriesRef
+        Reference to the selected electrical series.
+    """
+    refs = list_electrical_series(path)
+    if not refs:
+        raise ValueError("No electrical series found in NWB file")
+
+    if series_name is None:
+        if len(refs) > 1:
+            available = ", ".join(ref.series_name for ref in refs)
+            raise ValueError(
+                "Multiple electrical series found; provide series_name. "
+                f"Available series: {available}"
+            )
+        return refs[0]
+
+    for ref in refs:
+        if ref.series_name == series_name:
+            return ref
+
+    available = ", ".join(ref.series_name for ref in refs)
+    raise ValueError(
+        f"Electrical series {series_name!r} not found. Available series: {available}"
+    )
+
+
+def read_electrical_series_chunk(
+    path: str | Path,
+    series_name: str | None = None,
+    start: int = 0,
+    stop: int | None = None,
+) -> np.ndarray:
+    """
+    Read a sample-indexed chunk from an electrical series.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to an NWB file on disk.
+    series_name : str, optional
+        Name of the electrical series to read.
+    start : int, default=0
+        Starting sample index.
+    stop : int, optional
+        Stopping sample index. If omitted, read until the end.
+
+    Returns
+    -------
+    np.ndarray
+        Chunk of electrical data.
+    """
+    if start < 0:
+        raise ValueError("start must be non-negative")
+    if stop is not None and stop < start:
+        raise ValueError("stop must be greater than or equal to start")
+
+    source_path = validate_path(path)
+    selected_ref = get_electrical_series_ref(source_path, series_name=series_name)
+
+    with _open_nwb(source_path) as nwbfile:
+        series = _get_electrical_series_by_name(nwbfile, selected_ref.series_name)
+        data = series.data
+        return np.asarray(data[start:stop])
+
+
+def has_units_table(path: str | Path) -> bool:
+    """
+    Return whether an NWB file contains a units table.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to an NWB file on disk.
+
+    Returns
+    -------
+    bool
+        True when the NWB file contains spike-sorted units.
+    """
+    source_path = validate_path(path)
+
+    with _open_nwb(source_path) as nwbfile:
+        return getattr(nwbfile, "units", None) is not None
+
+
+def _require_pynwb() -> tuple[Any, Any]:
+    try:
+        from pynwb import NWBHDF5IO
+        from pynwb.ecephys import ElectricalSeries
+    except ImportError as exc:
+        raise ImportError(
+            "PyNWB is required for NWB loading. Install with "
+            "`pip install -e .[nwb]` or `pip install pynwb`."
+        ) from exc
+
+    return NWBHDF5IO, ElectricalSeries
+
+
+class _ReadNWB:
+    def __init__(self, path: Path):
+        NWBHDF5IO, _ = _require_pynwb()
+        self._io = NWBHDF5IO(str(path), "r")
+        self._file = None
+
+    def __enter__(self):
+        self._file = self._io.read()
+        return self._file
+
+    def __exit__(self, exc_type, exc, tb):
+        self._io.close()
+        return False
+
+
+def _open_nwb(path: Path) -> _ReadNWB:
+    return _ReadNWB(path)
+
+
+def _collect_electrical_series_refs(
+    nwbfile: Any,
+    source_path: Path,
+) -> list[ElectricalSeriesRef]:
+    _, electrical_series_type = _require_pynwb()
+    refs: list[ElectricalSeriesRef] = []
+
+    for obj in nwbfile.objects.values():
+        if not isinstance(obj, electrical_series_type):
+            continue
+
+        n_samples, n_channels = _shape_to_samples_and_channels(getattr(obj.data, "shape", None))
+        refs.append(
+            ElectricalSeriesRef(
+                source_path=source_path,
+                series_name=obj.name,
+                sampling_rate_hz=_coerce_float(getattr(obj, "rate", None)),
+                n_samples=n_samples,
+                n_channels=n_channels,
+                starting_time_s=_coerce_float(getattr(obj, "starting_time", None)),
+            )
+        )
+
+    refs.sort(key=lambda ref: ref.series_name)
+    return refs
+
+
+def _get_electrical_series_by_name(nwbfile: Any, series_name: str) -> Any:
+    _, electrical_series_type = _require_pynwb()
+
+    for obj in nwbfile.objects.values():
+        if isinstance(obj, electrical_series_type) and obj.name == series_name:
+            return obj
+
+    raise ValueError(f"Electrical series {series_name!r} not found in NWB file")
+
+
+def _shape_to_samples_and_channels(
+    shape: tuple[int, ...] | None,
+) -> tuple[int | None, int | None]:
+    if shape is None or len(shape) == 0:
+        return None, None
+    if len(shape) == 1:
+        return int(shape[0]), 1
+    return int(shape[0]), int(shape[1])
+
+
+def _estimate_duration_seconds(
+    nwbfile: Any,
+    electrical_series: list[ElectricalSeriesRef],
+) -> float | None:
+    if electrical_series:
+        primary = electrical_series[0]
+        if primary.n_samples is not None and primary.sampling_rate_hz:
+            return primary.n_samples / primary.sampling_rate_hz
+
+    units = getattr(nwbfile, "units", None)
+    if units is None:
+        return None
+
+    latest_spike = 0.0
+    for index in range(len(units.id)):
+        spike_times = np.asarray(units["spike_times"][index], dtype=float)
+        if spike_times.size:
+            latest_spike = max(latest_spike, float(spike_times.max()))
+
+    return latest_spike or None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    return float(value)

--- a/src/brain_organoid_criticality/loaders.py
+++ b/src/brain_organoid_criticality/loaders.py
@@ -215,7 +215,7 @@ def _collect_electrical_series_refs(
     _, electrical_series_type = _require_pynwb()
     refs: list[ElectricalSeriesRef] = []
 
-    for obj in nwbfile.objects.values():
+    for obj in nwbfile.acquisition.values():
         if not isinstance(obj, electrical_series_type):
             continue
 
@@ -238,7 +238,7 @@ def _collect_electrical_series_refs(
 def _get_electrical_series_by_name(nwbfile: Any, series_name: str) -> Any:
     _, electrical_series_type = _require_pynwb()
 
-    for obj in nwbfile.objects.values():
+    for obj in nwbfile.acquisition.values():
         if isinstance(obj, electrical_series_type) and obj.name == series_name:
             return obj
 
@@ -264,17 +264,7 @@ def _estimate_duration_seconds(
         if primary.n_samples is not None and primary.sampling_rate_hz:
             return primary.n_samples / primary.sampling_rate_hz
 
-    units = getattr(nwbfile, "units", None)
-    if units is None:
-        return None
-
-    latest_spike = 0.0
-    for index in range(len(units.id)):
-        spike_times = np.asarray(units["spike_times"][index], dtype=float)
-        if spike_times.size:
-            latest_spike = max(latest_spike, float(spike_times.max()))
-
-    return latest_spike or None
+    return None
 
 
 def _coerce_float(value: Any) -> float | None:

--- a/src/brain_organoid_criticality/models.py
+++ b/src/brain_organoid_criticality/models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass(slots=True)
+class RecordingSummary:
+    """Normalized summary of an NWB recording."""
+
+    source_path: Path
+    session_id: str | None
+    subject_id: str | None
+    experiment_description: str | None
+    identifier: str | None
+    sampling_rate_hz: float | None
+    duration_s: float | None
+    n_channels: int | None
+    has_raw_electrical_series: bool
+    has_units: bool
+    acquisition_names: list[str] = field(default_factory=list)
+    processing_modules: list[str] = field(default_factory=list)
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class ElectricalSeriesRef:
+    """Reference to an NWB electrical series without loading full data."""
+
+    source_path: Path
+    series_name: str
+    sampling_rate_hz: float | None
+    n_samples: int | None
+    n_channels: int | None
+    starting_time_s: float | None
+
+
+@dataclass(slots=True)
+class SortedSpikes:
+    """Canonical spike-times container used by downstream analyses."""
+
+    source_path: Path
+    unit_ids: np.ndarray
+    spike_times_by_unit: dict[int, np.ndarray]
+    t_start_s: float
+    t_stop_s: float
+    metadata: dict[str, object] = field(default_factory=dict)

--- a/src/brain_organoid_criticality/spikes.py
+++ b/src/brain_organoid_criticality/spikes.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from .io import validate_path
+from .loaders import _open_nwb, _require_pynwb
+from .models import SortedSpikes
+
+
+def load_units_from_nwb(path: str | Path) -> SortedSpikes:
+    """
+    Load spike-sorted units from an NWB units table.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to an NWB file on disk.
+
+    Returns
+    -------
+    SortedSpikes
+        Canonical spike-times representation extracted from the NWB file.
+    """
+    _require_pynwb()
+    source_path = validate_path(path)
+
+    with _open_nwb(source_path) as nwbfile:
+        units = getattr(nwbfile, "units", None)
+        if units is None:
+            raise ValueError("NWB file does not contain a units table")
+
+        unit_ids = np.asarray(units.id[:], dtype=int)
+        spike_times_by_unit: dict[int, np.ndarray] = {}
+        t_start_s = 0.0
+        t_stop_s = 0.0
+
+        for index, unit_id in enumerate(unit_ids.tolist()):
+            spike_times = np.asarray(units["spike_times"][index], dtype=float)
+            spike_times_by_unit[unit_id] = spike_times
+            if spike_times.size:
+                t_stop_s = max(t_stop_s, float(spike_times.max()))
+
+        sorted_spikes = SortedSpikes(
+            source_path=source_path,
+            unit_ids=unit_ids,
+            spike_times_by_unit=spike_times_by_unit,
+            t_start_s=t_start_s,
+            t_stop_s=t_stop_s,
+            metadata={
+                "session_id": getattr(nwbfile, "session_id", None),
+                "identifier": getattr(nwbfile, "identifier", None),
+            },
+        )
+        validate_sorted_spikes(sorted_spikes)
+        return sorted_spikes
+
+
+def flatten_spike_times(sorted_spikes: SortedSpikes) -> np.ndarray:
+    """
+    Flatten spike times across all units into a single sorted vector.
+
+    Parameters
+    ----------
+    sorted_spikes : SortedSpikes
+        Canonical spike-times container.
+
+    Returns
+    -------
+    np.ndarray
+        Sorted spike times across all units.
+    """
+    if not sorted_spikes.spike_times_by_unit:
+        return np.array([], dtype=float)
+
+    flattened = np.concatenate(
+        [
+            np.asarray(spike_times, dtype=float)
+            for spike_times in sorted_spikes.spike_times_by_unit.values()
+        ]
+    )
+    return np.sort(flattened)
+
+
+def validate_sorted_spikes(sorted_spikes: SortedSpikes) -> None:
+    """
+    Validate a canonical spike-times container.
+
+    Parameters
+    ----------
+    sorted_spikes : SortedSpikes
+        Canonical spike-times container.
+    """
+    if sorted_spikes.t_start_s < 0:
+        raise ValueError("t_start_s must be non-negative")
+    if sorted_spikes.t_stop_s < sorted_spikes.t_start_s:
+        raise ValueError("t_stop_s must be greater than or equal to t_start_s")
+
+    unique_unit_ids = np.unique(sorted_spikes.unit_ids)
+    if unique_unit_ids.size != sorted_spikes.unit_ids.size:
+        raise ValueError("unit_ids must be unique")
+
+    for unit_id in sorted_spikes.unit_ids.tolist():
+        if unit_id not in sorted_spikes.spike_times_by_unit:
+            raise ValueError(f"Missing spike times for unit_id={unit_id}")
+
+        spike_times = np.asarray(sorted_spikes.spike_times_by_unit[unit_id], dtype=float)
+        if spike_times.ndim != 1:
+            raise ValueError("Spike times must be one-dimensional arrays")
+        if np.any(~np.isfinite(spike_times)):
+            raise ValueError("Spike times must be finite")
+        if np.any(spike_times < sorted_spikes.t_start_s):
+            raise ValueError("Spike times must be greater than or equal to t_start_s")
+        if np.any(spike_times > sorted_spikes.t_stop_s):
+            raise ValueError("Spike times must be less than or equal to t_stop_s")
+        if spike_times.size > 1 and np.any(np.diff(spike_times) < 0):
+            raise ValueError("Spike times must be sorted within each unit")

--- a/tests/test_nwb_io.py
+++ b/tests/test_nwb_io.py
@@ -17,6 +17,7 @@ from brain_organoid_criticality.spikes import load_units_from_nwb
 
 pynwb = pytest.importorskip("pynwb")
 ElectricalSeries = pytest.importorskip("pynwb.ecephys").ElectricalSeries
+LFP = pytest.importorskip("pynwb.ecephys").LFP
 NWBFile = pynwb.NWBFile
 NWBHDF5IO = pynwb.NWBHDF5IO
 
@@ -50,7 +51,37 @@ def test_inspect_nwb_and_load_units(tmp_path) -> None:
     assert spikes.t_stop_s == pytest.approx(0.5)
 
 
-def _write_test_nwb(path) -> None:
+def test_list_electrical_series_excludes_processed_lfp_series(tmp_path) -> None:
+    nwb_path = tmp_path / "processed_only.nwb"
+    _write_test_nwb(nwb_path, include_raw_acquisition=False, include_processed_lfp=True)
+
+    summary = inspect_nwb(nwb_path)
+    electrical_series = list_electrical_series(nwb_path)
+
+    assert summary.has_raw_electrical_series is False
+    assert summary.duration_s is None
+    assert electrical_series == []
+
+
+def test_inspect_nwb_units_only_does_not_infer_duration_from_spikes(tmp_path) -> None:
+    nwb_path = tmp_path / "units_only.nwb"
+    _write_test_nwb(nwb_path, include_raw_acquisition=False, include_processed_lfp=False)
+
+    summary = inspect_nwb(nwb_path)
+    spikes = load_units_from_nwb(nwb_path)
+
+    assert summary.has_raw_electrical_series is False
+    assert summary.has_units is True
+    assert summary.duration_s is None
+    assert spikes.t_stop_s == pytest.approx(0.5)
+
+
+def _write_test_nwb(
+    path,
+    *,
+    include_raw_acquisition: bool = True,
+    include_processed_lfp: bool = False,
+) -> None:
     nwbfile = NWBFile(
         session_description="test session",
         identifier="TEST123",
@@ -83,14 +114,29 @@ def _write_test_nwb(path) -> None:
         description="all electrodes",
     )
     data = np.arange(20, dtype=float).reshape(10, 2)
-    electrical_series = ElectricalSeries(
-        name="ElectricalSeries",
-        data=data,
-        electrodes=electrodes,
-        rate=1000.0,
-        starting_time=0.0,
-    )
-    nwbfile.add_acquisition(electrical_series)
+    if include_raw_acquisition:
+        electrical_series = ElectricalSeries(
+            name="ElectricalSeries",
+            data=data,
+            electrodes=electrodes,
+            rate=1000.0,
+            starting_time=0.0,
+        )
+        nwbfile.add_acquisition(electrical_series)
+
+    if include_processed_lfp:
+        lfp_module = nwbfile.create_processing_module(
+            name="ecephys",
+            description="processed ecephys signals",
+        )
+        lfp_series = ElectricalSeries(
+            name="ProcessedLFP",
+            data=data,
+            electrodes=electrodes,
+            rate=1000.0,
+            starting_time=0.0,
+        )
+        lfp_module.add(LFP(electrical_series=lfp_series))
 
     nwbfile.add_unit(id=1, spike_times=[0.1, 0.3])
     nwbfile.add_unit(id=2, spike_times=[0.2, 0.5])

--- a/tests/test_nwb_io.py
+++ b/tests/test_nwb_io.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import numpy as np
+import pytest
+
+from brain_organoid_criticality.loaders import (
+    get_electrical_series_ref,
+    has_units_table,
+    inspect_nwb,
+    list_electrical_series,
+    read_electrical_series_chunk,
+)
+from brain_organoid_criticality.spikes import load_units_from_nwb
+
+
+pynwb = pytest.importorskip("pynwb")
+ElectricalSeries = pytest.importorskip("pynwb.ecephys").ElectricalSeries
+NWBFile = pynwb.NWBFile
+NWBHDF5IO = pynwb.NWBHDF5IO
+
+
+def test_inspect_nwb_and_load_units(tmp_path) -> None:
+    nwb_path = tmp_path / "example.nwb"
+    _write_test_nwb(nwb_path)
+
+    summary = inspect_nwb(nwb_path)
+    electrical_series = list_electrical_series(nwb_path)
+    selected_series = get_electrical_series_ref(nwb_path, "ElectricalSeries")
+    chunk = read_electrical_series_chunk(nwb_path, start=1, stop=4)
+    spikes = load_units_from_nwb(nwb_path)
+
+    assert summary.has_raw_electrical_series is True
+    assert summary.has_units is True
+    assert summary.sampling_rate_hz == pytest.approx(1000.0)
+    assert summary.n_channels == 2
+    assert summary.duration_s == pytest.approx(0.01)
+    assert has_units_table(nwb_path) is True
+
+    assert len(electrical_series) == 1
+    assert selected_series.series_name == "ElectricalSeries"
+    assert selected_series.n_samples == 10
+    assert selected_series.n_channels == 2
+    np.testing.assert_allclose(chunk, np.arange(2, 8, dtype=float).reshape(3, 2))
+
+    np.testing.assert_array_equal(spikes.unit_ids, np.array([1, 2]))
+    np.testing.assert_allclose(spikes.spike_times_by_unit[1], np.array([0.1, 0.3]))
+    np.testing.assert_allclose(spikes.spike_times_by_unit[2], np.array([0.2, 0.5]))
+    assert spikes.t_stop_s == pytest.approx(0.5)
+
+
+def _write_test_nwb(path) -> None:
+    nwbfile = NWBFile(
+        session_description="test session",
+        identifier="TEST123",
+        session_start_time=datetime.now(timezone.utc),
+        session_id="session-1",
+        experiment_description="synthetic ecephys test",
+    )
+
+    device = nwbfile.create_device(name="test-probe")
+    electrode_group = nwbfile.create_electrode_group(
+        name="group",
+        description="test electrodes",
+        location="VISp",
+        device=device,
+    )
+
+    for index in range(2):
+        nwbfile.add_electrode(
+            x=float(index),
+            y=0.0,
+            z=0.0,
+            imp=np.nan,
+            location="VISp",
+            filtering="none",
+            group=electrode_group,
+        )
+
+    electrodes = nwbfile.create_electrode_table_region(
+        region=[0, 1],
+        description="all electrodes",
+    )
+    data = np.arange(20, dtype=float).reshape(10, 2)
+    electrical_series = ElectricalSeries(
+        name="ElectricalSeries",
+        data=data,
+        electrodes=electrodes,
+        rate=1000.0,
+        starting_time=0.0,
+    )
+    nwbfile.add_acquisition(electrical_series)
+
+    nwbfile.add_unit(id=1, spike_times=[0.1, 0.3])
+    nwbfile.add_unit(id=2, spike_times=[0.2, 0.5])
+
+    with NWBHDF5IO(path, "w") as io:
+        io.write(nwbfile)

--- a/tests/test_spikes.py
+++ b/tests/test_spikes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brain_organoid_criticality.models import SortedSpikes
+from brain_organoid_criticality.spikes import flatten_spike_times, validate_sorted_spikes
+
+
+def test_flatten_spike_times_returns_sorted_population_vector() -> None:
+    sorted_spikes = SortedSpikes(
+        source_path=Path("example.nwb"),
+        unit_ids=np.array([1, 2]),
+        spike_times_by_unit={
+            1: np.array([0.3, 0.9]),
+            2: np.array([0.1, 0.4]),
+        },
+        t_start_s=0.0,
+        t_stop_s=1.0,
+    )
+
+    flattened = flatten_spike_times(sorted_spikes)
+
+    np.testing.assert_allclose(flattened, np.array([0.1, 0.3, 0.4, 0.9]))
+
+
+def test_validate_sorted_spikes_rejects_unsorted_unit_times() -> None:
+    sorted_spikes = SortedSpikes(
+        source_path=Path("example.nwb"),
+        unit_ids=np.array([1]),
+        spike_times_by_unit={1: np.array([0.4, 0.1])},
+        t_start_s=0.0,
+        t_stop_s=1.0,
+    )
+
+    with pytest.raises(ValueError, match="sorted within each unit"):
+        validate_sorted_spikes(sorted_spikes)


### PR DESCRIPTION
## Summary

This PR adds the first NWB-facing ingestion slice for the project.

## What Changed

- added normalized models for `RecordingSummary`, `ElectricalSeriesRef`, and `SortedSpikes`
- added NWB loading utilities for inspecting local `.nwb` files, listing/selecting `ElectricalSeries`, checking for a `units` table, and reading electrical trace chunks
- added spike extraction utilities to load NWB `units` into the package-level spike-times container
- added `scripts/inspect_nwb.py` for quick manual inspection
- added optional `pynwb` support via the `nwb` extra in `pyproject.toml`
- added initial tests, including a synthetic NWB round-trip with raw traces plus units
- documented the subsystem in `docs/nwb_ingestion.md` and recorded the work in `CHANGELOG.md`

## Why

Issue #7 tracks the data-loading utility layer. This change establishes a clean NWB boundary so downstream criticality analyses can depend on normalized package models rather than on raw PyNWB objects.

## Impact

The project can now:

- inspect local NWB files for raw traces and units
- extract spike times from NWB `units` tables into a canonical container
- read electrical trace chunks for future sorter integration
- validate this upstream layer with automated tests

## Validation

- `python -m compileall src tests scripts`
- `HOME=/Users/asgnxt/brain_organoid_criticality PYNWB_NO_CACHE_DIR=1 .venv/bin/python -m pytest tests`

Closes #7