### PR TITLE
chore:add pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,7 @@ nwb = ["pynwb"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]


### PR DESCRIPTION
  ## Summary
  Adds basic pytest configuration so tests run from the repository root with `pytest`.

  ## Validation
  - `pytest` passes: 5 passed, 1 warning