### PR TITLE
chore: add dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ dependencies = ["numpy"]
 
 [project.optional-dependencies]
 nwb = ["pynwb"]
+dev = [
+  "pytest",
+  "pytest-cov",
+  "ruff",
+  "mypy",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -37,3 +43,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true


### PR DESCRIPTION
  ## Summary
  Adds a `dev` optional dependency group for local development tools.

  Developers can now install the project with development tooling using:

  ```bash
  pip install -e ".[dev]"

  Or with NWB support included:

  pip install -e ".[dev,nwb]"

  ## Changes

  - Adds pytest
  - Adds pytest-cov
  - Adds ruff
  - Adds mypy
  - Adds basic mypy config to ignore missing type information from untyped third-party packages

  ## Validation

  - pytest passed
  - ruff check src/ tests/ passed
  - mypy src/ passed