### PR TITLE
test: add shared pytest fixtures (#19)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brain_organoid_criticality.models import SortedSpikes
+
+
+@pytest.fixture()
+def sorted_spikes_two_units() -> SortedSpikes:
+    return SortedSpikes(
+        source_path=Path("synthetic.nwb"),
+        unit_ids=np.array([1, 2]),
+        spike_times_by_unit={
+            1: np.array([0.1, 0.3, 0.5, 0.7, 0.9]),
+            2: np.array([0.2, 0.4, 0.6, 0.8]),
+        },
+        t_start_s=0.0,
+        t_stop_s=1.0,
+    )
+
+
+@pytest.fixture()
+def sorted_spikes_single_unit() -> SortedSpikes:
+    return SortedSpikes(
+        source_path=Path("synthetic.nwb"),
+        unit_ids=np.array([1]),
+        spike_times_by_unit={1: np.array([0.1, 0.5])},
+        t_start_s=0.0,
+        t_stop_s=1.0,
+    )
+
+
+@pytest.fixture()
+def sorted_spikes_empty() -> SortedSpikes:
+    return SortedSpikes(
+        source_path=Path("synthetic.nwb"),
+        unit_ids=np.array([], dtype=int),
+        spike_times_by_unit={},
+        t_start_s=0.0,
+        t_stop_s=0.0,
+    )
+
+
+@pytest.fixture()
+def synthetic_nwb_path(tmp_path):
+    pynwb = pytest.importorskip("pynwb")
+    ElectricalSeries = pytest.importorskip("pynwb.ecephys").ElectricalSeries
+    NWBFile = pynwb.NWBFile
+    NWBHDF5IO = pynwb.NWBHDF5IO
+
+    nwb_path = tmp_path / "synthetic.nwb"
+
+    nwbfile = NWBFile(
+        session_description="synthetic test session",
+        identifier="SYNTH001",
+        session_start_time=datetime.now(timezone.utc),
+        session_id="session-synth",
+        experiment_description="synthetic ecephys fixture",
+    )
+
+    device = nwbfile.create_device(name="test-probe")
+    electrode_group = nwbfile.create_electrode_group(
+        name="group",
+        description="test electrodes",
+        location="VISp",
+        device=device,
+    )
+    for i in range(2):
+        nwbfile.add_electrode(
+            x=float(i), y=0.0, z=0.0,
+            imp=np.nan, location="VISp",
+            filtering="none", group=electrode_group,
+        )
+
+    electrodes = nwbfile.create_electrode_table_region(
+        region=[0, 1], description="all electrodes"
+    )
+    data = np.arange(20, dtype=float).reshape(10, 2)
+    nwbfile.add_acquisition(
+        ElectricalSeries(
+            name="ElectricalSeries",
+            data=data,
+            electrodes=electrodes,
+            rate=1000.0,
+            starting_time=0.0,
+        )
+    )
+    nwbfile.add_unit(id=1, spike_times=[0.1, 0.3])
+    nwbfile.add_unit(id=2, spike_times=[0.2, 0.5])
+
+    with NWBHDF5IO(nwb_path, "w") as io:
+        io.write(nwbfile)
+
+    return nwb_path

--- a/tests/test_nwb_io.py
+++ b/tests/test_nwb_io.py
@@ -22,22 +22,19 @@ NWBFile = pynwb.NWBFile
 NWBHDF5IO = pynwb.NWBHDF5IO
 
 
-def test_inspect_nwb_and_load_units(tmp_path) -> None:
-    nwb_path = tmp_path / "example.nwb"
-    _write_test_nwb(nwb_path)
-
-    summary = inspect_nwb(nwb_path)
-    electrical_series = list_electrical_series(nwb_path)
-    selected_series = get_electrical_series_ref(nwb_path, "ElectricalSeries")
-    chunk = read_electrical_series_chunk(nwb_path, start=1, stop=4)
-    spikes = load_units_from_nwb(nwb_path)
+def test_inspect_nwb_and_load_units(synthetic_nwb_path) -> None:
+    summary = inspect_nwb(synthetic_nwb_path)
+    electrical_series = list_electrical_series(synthetic_nwb_path)
+    selected_series = get_electrical_series_ref(synthetic_nwb_path, "ElectricalSeries")
+    chunk = read_electrical_series_chunk(synthetic_nwb_path, start=1, stop=4)
+    spikes = load_units_from_nwb(synthetic_nwb_path)
 
     assert summary.has_raw_electrical_series is True
     assert summary.has_units is True
     assert summary.sampling_rate_hz == pytest.approx(1000.0)
     assert summary.n_channels == 2
     assert summary.duration_s == pytest.approx(0.01)
-    assert has_units_table(nwb_path) is True
+    assert has_units_table(synthetic_nwb_path) is True
 
     assert len(electrical_series) == 1
     assert selected_series.series_name == "ElectricalSeries"

--- a/tests/test_spikes.py
+++ b/tests/test_spikes.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 
@@ -9,26 +7,23 @@ from brain_organoid_criticality.models import SortedSpikes
 from brain_organoid_criticality.spikes import flatten_spike_times, validate_sorted_spikes
 
 
-def test_flatten_spike_times_returns_sorted_population_vector() -> None:
-    sorted_spikes = SortedSpikes(
-        source_path=Path("example.nwb"),
-        unit_ids=np.array([1, 2]),
-        spike_times_by_unit={
-            1: np.array([0.3, 0.9]),
-            2: np.array([0.1, 0.4]),
-        },
-        t_start_s=0.0,
-        t_stop_s=1.0,
-    )
+def test_flatten_spike_times_returns_sorted_population_vector(
+    sorted_spikes_two_units: SortedSpikes,
+) -> None:
+    flattened = flatten_spike_times(sorted_spikes_two_units)
 
-    flattened = flatten_spike_times(sorted_spikes)
+    assert flattened.ndim == 1
+    assert np.all(np.diff(flattened) >= 0)
 
-    np.testing.assert_allclose(flattened, np.array([0.1, 0.3, 0.4, 0.9]))
+
+def test_flatten_spike_times_empty(sorted_spikes_empty: SortedSpikes) -> None:
+    flattened = flatten_spike_times(sorted_spikes_empty)
+    assert flattened.size == 0
 
 
 def test_validate_sorted_spikes_rejects_unsorted_unit_times() -> None:
-    sorted_spikes = SortedSpikes(
-        source_path=Path("example.nwb"),
+    bad = SortedSpikes(
+        source_path=__file__,
         unit_ids=np.array([1]),
         spike_times_by_unit={1: np.array([0.4, 0.1])},
         t_start_s=0.0,
@@ -36,4 +31,4 @@ def test_validate_sorted_spikes_rejects_unsorted_unit_times() -> None:
     )
 
     with pytest.raises(ValueError, match="sorted within each unit"):
-        validate_sorted_spikes(sorted_spikes)
+        validate_sorted_spikes(bad)


### PR DESCRIPTION
 - Adds `tests/conftest.py` with reusable `SortedSpikes` fixtures (`sorted_spikes_two_units`, `sorted_spikes_single_unit`,
  `sorted_spikes_empty`) and a `synthetic_nwb_path` fixture
  - Refactors `test_spikes.py` to use fixtures instead of inline construction
  - Refactors `test_nwb_io.py` happy-path test to use `synthetic_nwb_path` fixture

  Closes #19

  ## Test plan
  - [x] `pytest tests/` passes
  - [x] `ruff check src/ tests/` clean
  - [x] `mypy src/` clean