### PR TITLE
feat: Phase 1 metric MVP — data sufficiency + distance-to-criticality (#9)

### DIFF
--- a/src/brain_organoid_criticality/__init__.py
+++ b/src/brain_organoid_criticality/__init__.py
@@ -7,7 +7,10 @@ from .loaders import (
     list_electrical_series,
     read_electrical_series_chunk,
 )
+from .metrics import branching_ratio, distance_to_criticality
 from .models import (
+    BranchingRatioEstimate,
+    DCCResult,
     ElectricalSeriesRef,
     RecordingSummary,
     SortedSpikes,
@@ -19,13 +22,17 @@ from .spikes import flatten_spike_times, load_units_from_nwb, validate_sorted_sp
 __version__ = "0.1.0"
 
 __all__ = [
+    "BranchingRatioEstimate",
+    "DCCResult",
     "ElectricalSeriesRef",
     "RecordingSummary",
     "SortedSpikes",
     "SufficiencyReport",
     "__version__",
     "bin_spike_times",
+    "branching_ratio",
     "check_sufficiency",
+    "distance_to_criticality",
     "flatten_spike_times",
     "get_electrical_series_ref",
     "has_units_table",

--- a/src/brain_organoid_criticality/__init__.py
+++ b/src/brain_organoid_criticality/__init__.py
@@ -7,7 +7,13 @@ from .loaders import (
     list_electrical_series,
     read_electrical_series_chunk,
 )
-from .models import ElectricalSeriesRef, RecordingSummary, SortedSpikes
+from .models import (
+    ElectricalSeriesRef,
+    RecordingSummary,
+    SortedSpikes,
+    SufficiencyReport,
+)
+from .quality import check_sufficiency
 from .spikes import flatten_spike_times, load_units_from_nwb, validate_sorted_spikes
 
 __version__ = "0.1.0"
@@ -16,8 +22,10 @@ __all__ = [
     "ElectricalSeriesRef",
     "RecordingSummary",
     "SortedSpikes",
+    "SufficiencyReport",
     "__version__",
     "bin_spike_times",
+    "check_sufficiency",
     "flatten_spike_times",
     "get_electrical_series_ref",
     "has_units_table",

--- a/src/brain_organoid_criticality/metrics.py
+++ b/src/brain_organoid_criticality/metrics.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .models import BranchingRatioEstimate, DCCResult, SufficiencyReport
+
+
+def _autoregressive_slopes(activity: np.ndarray, k_max: int) -> np.ndarray:
+    """Return the regression slopes ``r(k) = Cov(A_t, A_{t+k}) / Var(A_t)``.
+
+    Slopes are computed for lags ``k = 1 .. k_max`` from the biased
+    autocovariance via the FFT, which is ``O(n log n)`` rather than
+    ``O(n * k_max)``.
+    """
+    centered = activity - activity.mean()
+    n = centered.size
+    size = int(2 ** np.ceil(np.log2(2 * n)))
+    spectrum = np.fft.rfft(centered, n=size)
+    autocov = np.fft.irfft(spectrum * np.conjugate(spectrum), n=size)[: k_max + 1]
+    autocov = autocov / n
+    return autocov[1:] / autocov[0]
+
+
+def _estimate_sigma(slopes: np.ndarray) -> tuple[float, float]:
+    """Estimate sigma and the fit R-squared from autoregressive slopes.
+
+    For a branching process ``r(k) = b * sigma**k``, so successive slopes obey
+    ``r(k+1) = sigma * r(k)`` regardless of the offset ``b``. Sigma is the
+    least-squares slope of ``r(k+1)`` on ``r(k)`` through the origin; weighting
+    by ``r(k)`` lets the high-amplitude low lags dominate and suppresses the
+    noise floor at high lags (so an uncorrelated series yields sigma near 0).
+    """
+    current = slopes[:-1]
+    following = slopes[1:]
+    denom = float(np.dot(current, current))
+    sigma = float(np.dot(current, following) / denom)
+
+    predicted = sigma * current
+    ss_res = float(np.sum((following - predicted) ** 2))
+    ss_tot = float(np.sum((following - following.mean()) ** 2))
+    r_squared = 1.0 - ss_res / ss_tot if ss_tot > 0.0 else 0.0
+    r_squared = float(np.clip(r_squared, 0.0, 1.0))
+    return sigma, r_squared
+
+
+def branching_ratio(
+    counts: np.ndarray,
+    *,
+    k_max: int = 150,
+    method: str = "mr",
+) -> BranchingRatioEstimate:
+    """Estimate the branching ratio sigma from binned population activity.
+
+    Implements the multistep-regression (MR) estimator of Wilting &
+    Priesemann (2018). The autoregressive slopes ``r(k) = Cov(A_t, A_{t+k}) /
+    Var(A_t)`` decay as ``r(k) = b * sigma**k`` for a branching process; sigma
+    is recovered from the geometric decay rate and is invariant to the offset
+    ``b`` that spatial subsampling introduces, which is why the MR estimator is
+    robust to MEA-style subsampling.
+
+    Parameters
+    ----------
+    counts : np.ndarray
+        Binned population spike counts, one value per time bin.
+    k_max : int, optional
+        Largest lag (in bins) used to fit the slope decay. Reduced internally
+        when the series is too short to support it. Default ``150``.
+    method : str, optional
+        Estimator variant. Only ``"mr"`` (multistep regression) is supported.
+        Default ``"mr"``.
+
+    Returns
+    -------
+    BranchingRatioEstimate
+        The estimated sigma with its autocorrelation time, fit quality, and
+        the slopes used.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is not ``"mr"``, the series has fewer than three bins,
+        ``k_max`` is not positive, or the activity has zero variance.
+    """
+    if method != "mr":
+        raise ValueError(f"Unknown method {method!r}; only 'mr' is supported")
+    if k_max < 1:
+        raise ValueError(f"k_max must be positive, got {k_max}")
+
+    activity = np.asarray(counts, dtype=float)
+    n = activity.size
+    if n < 3:
+        raise ValueError(
+            f"counts must have at least 3 bins to estimate sigma, got {n}"
+        )
+    if activity.var() == 0.0:
+        raise ValueError("population activity has zero variance")
+
+    k_max_eff = min(k_max, n - 2)
+    slopes = _autoregressive_slopes(activity, k_max_eff)
+    k_used = np.arange(1, k_max_eff + 1)
+
+    sigma, r_squared = _estimate_sigma(slopes)
+    tau_bins = -1.0 / np.log(sigma) if 0.0 < sigma < 1.0 else float("inf")
+
+    return BranchingRatioEstimate(
+        sigma=sigma,
+        tau_bins=tau_bins,
+        r_squared=r_squared,
+        k_used=k_used,
+        r_values=slopes,
+    )
+
+
+def _block_bootstrap_indices(
+    n: int, block_size: int, rng: np.random.Generator
+) -> np.ndarray:
+    """Build resample indices from contiguous blocks covering ``n`` samples."""
+    n_blocks = int(np.ceil(n / block_size))
+    starts = rng.integers(0, n - block_size + 1, size=n_blocks)
+    offsets = np.arange(block_size)
+    indices = (starts[:, None] + offsets[None, :]).ravel()
+    return indices[:n]
+
+
+def distance_to_criticality(
+    counts: np.ndarray,
+    *,
+    n_bootstrap: int = 1000,
+    sufficiency: SufficiencyReport | None = None,
+    k_max: int = 150,
+    block_size: int | None = None,
+    seed: int | None = None,
+) -> DCCResult:
+    """Compute the distance-to-criticality coefficient ``DCC = 1 - sigma``.
+
+    The branching ratio sigma is estimated with the MR estimator and a
+    confidence interval on ``DCC`` is obtained by a moving-block bootstrap that
+    preserves the temporal correlation the estimator depends on. When a
+    :class:`SufficiencyReport` is supplied and does not pass, no point estimate
+    is computed and all estimate fields are returned as ``None``.
+
+    Parameters
+    ----------
+    counts : np.ndarray
+        Binned population spike counts, one value per time bin.
+    n_bootstrap : int, optional
+        Number of bootstrap resamples. Default ``1000``.
+    sufficiency : SufficiencyReport or None, optional
+        If provided and ``sufficiency.passes`` is ``False``, the function
+        refuses to return a point estimate. Default ``None``.
+    k_max : int, optional
+        Largest lag passed to :func:`branching_ratio`. Default ``150``.
+    block_size : int or None, optional
+        Block length (in bins) for the moving-block bootstrap. Defaults to
+        ``k_max`` so each block preserves the lag structure the estimator uses.
+    seed : int or None, optional
+        Seed for the bootstrap resampling, for reproducibility. Default
+        ``None``.
+
+    Returns
+    -------
+    DCCResult
+        The DCC point estimate, bootstrap confidence interval, and the
+        underlying branching-ratio estimate; estimate fields are ``None`` when
+        sufficiency fails.
+
+    Raises
+    ------
+    ValueError
+        Propagated from :func:`branching_ratio` for invalid input when a point
+        estimate is computed.
+    """
+    if sufficiency is not None and not sufficiency.passes:
+        return DCCResult(
+            dcc=None,
+            ci_lower=None,
+            ci_upper=None,
+            branching=None,
+            sufficiency=sufficiency,
+            bootstrap_n=n_bootstrap,
+        )
+
+    activity = np.asarray(counts, dtype=float)
+    branching = branching_ratio(activity, k_max=k_max)
+    dcc = 1.0 - branching.sigma
+
+    effective_block = block_size if block_size is not None else k_max
+    effective_block = min(effective_block, activity.size - 2)
+    rng = np.random.default_rng(seed)
+
+    dcc_samples = np.empty(n_bootstrap, dtype=float)
+    for i in range(n_bootstrap):
+        indices = _block_bootstrap_indices(activity.size, effective_block, rng)
+        resampled = activity[indices]
+        sample = branching_ratio(resampled, k_max=k_max)
+        dcc_samples[i] = 1.0 - sample.sigma
+
+    ci_lower = float(np.percentile(dcc_samples, 2.5))
+    ci_upper = float(np.percentile(dcc_samples, 97.5))
+
+    return DCCResult(
+        dcc=dcc,
+        ci_lower=ci_lower,
+        ci_upper=ci_upper,
+        branching=branching,
+        sufficiency=sufficiency,
+        bootstrap_n=n_bootstrap,
+    )

--- a/src/brain_organoid_criticality/models.py
+++ b/src/brain_organoid_criticality/models.py
@@ -87,3 +87,67 @@ class SufficiencyReport:
     n_bins_at_default: int
     warnings: list[str] = field(default_factory=list)
     failures: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class BranchingRatioEstimate:
+    """Multistep-regression estimate of the branching ratio sigma.
+
+    The estimator follows Wilting & Priesemann (2018): autoregressive slopes
+    ``r(k) = Cov(A_t, A_{t+k}) / Var(A_t)`` decay geometrically as
+    ``r(k) = b * sigma**k`` for a branching process, so ``sigma`` is recovered
+    from the decay rate and is invariant to the multiplicative offset ``b``
+    introduced by spatial subsampling.
+
+    Attributes
+    ----------
+    sigma : float
+        Estimated branching ratio. ``sigma < 1`` subcritical, ``~1`` critical.
+    tau_bins : float
+        Autocorrelation time in bins, ``-1 / log(sigma)``; ``inf`` when
+        ``sigma >= 1``.
+    r_squared : float
+        Goodness of fit of the geometric-decay model to the slopes ``r(k)``.
+    k_used : np.ndarray
+        Lags (in bins) at which slopes were evaluated.
+    r_values : np.ndarray
+        Autoregressive slopes ``r(k)`` at each lag in ``k_used``.
+    """
+
+    sigma: float
+    tau_bins: float
+    r_squared: float
+    k_used: np.ndarray
+    r_values: np.ndarray
+
+
+@dataclass(slots=True)
+class DCCResult:
+    """Distance-to-criticality result with a bootstrap confidence interval.
+
+    ``dcc = 1 - sigma``. All estimate fields are ``None`` when the supplied
+    :class:`SufficiencyReport` does not pass, in which case no point estimate
+    is computed.
+
+    Attributes
+    ----------
+    dcc : float or None
+        Distance to criticality, ``1 - sigma``.
+    ci_lower : float or None
+        Lower bound of the bootstrap confidence interval on ``dcc``.
+    ci_upper : float or None
+        Upper bound of the bootstrap confidence interval on ``dcc``.
+    branching : BranchingRatioEstimate or None
+        The underlying branching-ratio estimate.
+    sufficiency : SufficiencyReport or None
+        The sufficiency report consulted, if any.
+    bootstrap_n : int
+        Number of bootstrap resamples requested.
+    """
+
+    dcc: float | None
+    ci_lower: float | None
+    ci_upper: float | None
+    branching: BranchingRatioEstimate | None
+    sufficiency: SufficiencyReport | None
+    bootstrap_n: int

--- a/src/brain_organoid_criticality/models.py
+++ b/src/brain_organoid_criticality/models.py
@@ -47,3 +47,43 @@ class SortedSpikes:
     t_start_s: float
     t_stop_s: float
     metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class SufficiencyReport:
+    """Data-sufficiency descriptors and verdict for a recording.
+
+    Produced by :func:`brain_organoid_criticality.quality.check_sufficiency`.
+    ``passes`` is ``False`` whenever any descriptor falls below a hard
+    threshold; ``warnings`` collects advisory issues that do not by themselves
+    block a metric estimate, while ``failures`` collects threshold violations
+    that do.
+
+    Attributes
+    ----------
+    passes : bool
+        ``True`` only when ``failures`` is empty.
+    n_units : int
+        Number of units in the recording.
+    n_spikes : int
+        Total number of spikes summed across all units.
+    duration_s : float
+        Recording duration in seconds (``t_stop_s - t_start_s``).
+    mean_firing_rate_hz : float
+        Mean per-unit firing rate in hertz.
+    n_bins_at_default : int
+        Number of bins the recording yields at the assessed bin size.
+    warnings : list of str
+        Advisory messages naming both the observed value and the bound.
+    failures : list of str
+        Hard-threshold violations naming both the observed value and the bound.
+    """
+
+    passes: bool
+    n_units: int
+    n_spikes: int
+    duration_s: float
+    mean_firing_rate_hz: float
+    n_bins_at_default: int
+    warnings: list[str] = field(default_factory=list)
+    failures: list[str] = field(default_factory=list)

--- a/src/brain_organoid_criticality/quality.py
+++ b/src/brain_organoid_criticality/quality.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from .models import SortedSpikes, SufficiencyReport
+
+
+def check_sufficiency(
+    sorted_spikes: SortedSpikes,
+    *,
+    min_units: int = 20,
+    min_duration_s: float = 60.0,
+    firing_rate_range_hz: tuple[float, float] = (0.01, 100.0),
+    min_bins_for_bootstrap: int = 1000,
+    bin_size_s: float = 0.003,
+) -> SufficiencyReport:
+    """Assess whether a recording can support a reliable DCC estimate.
+
+    The function derives the descriptors named in the MVP specification
+    (``n_units``, ``n_spikes``, ``duration_s``, ``mean_firing_rate_hz``,
+    ``n_bins_at_default``) and compares each against a configurable threshold.
+    Violations of the unit-count, duration, and bin-count thresholds are
+    recorded as ``failures`` and set ``passes`` to ``False``; an implausible
+    mean firing rate is recorded as a ``warning`` only.
+
+    Parameters
+    ----------
+    sorted_spikes : SortedSpikes
+        Canonical spike-times container to assess.
+    min_units : int, optional
+        Minimum number of units. Below this, multistep-regression ``tau`` fits
+        become unstable on subsampled MEA data. Default ``20``.
+    min_duration_s : float, optional
+        Minimum recording duration in seconds. Default ``60``.
+    firing_rate_range_hz : tuple of (float, float), optional
+        Inclusive plausible range for the mean per-unit firing rate in hertz.
+        Rates outside this range usually indicate noise or duplicate units.
+        Default ``(0.01, 100.0)``.
+    min_bins_for_bootstrap : int, optional
+        Minimum number of bins at ``bin_size_s`` needed for a stable bootstrap.
+        Default ``1000``.
+    bin_size_s : float, optional
+        Bin size in seconds used to compute ``n_bins_at_default``.
+        Default ``0.003``.
+
+    Returns
+    -------
+    SufficiencyReport
+        Structured descriptors, ``warnings``, ``failures``, and a ``passes``
+        verdict that is ``True`` only when no failure is recorded.
+
+    Raises
+    ------
+    ValueError
+        If ``bin_size_s`` is not positive.
+    """
+    if bin_size_s <= 0:
+        raise ValueError(f"bin_size_s must be positive, got {bin_size_s}")
+
+    n_units = int(sorted_spikes.unit_ids.size)
+    n_spikes = int(
+        sum(times.size for times in sorted_spikes.spike_times_by_unit.values())
+    )
+    duration_s = float(sorted_spikes.t_stop_s - sorted_spikes.t_start_s)
+
+    if n_units > 0 and duration_s > 0:
+        mean_firing_rate_hz = n_spikes / (n_units * duration_s)
+    else:
+        mean_firing_rate_hz = 0.0
+
+    n_bins_at_default = int(duration_s // bin_size_s) if duration_s > 0 else 0
+
+    warnings: list[str] = []
+    failures: list[str] = []
+
+    if n_units < min_units:
+        failures.append(
+            f"n_units={n_units} is below the minimum of {min_units}"
+        )
+    if duration_s < min_duration_s:
+        failures.append(
+            f"duration_s={duration_s:.3f} is below the minimum of {min_duration_s}"
+        )
+    if n_bins_at_default < min_bins_for_bootstrap:
+        failures.append(
+            f"n_bins_at_default={n_bins_at_default} is below the minimum of "
+            f"{min_bins_for_bootstrap} bins required for bootstrap"
+        )
+
+    low, high = firing_rate_range_hz
+    if mean_firing_rate_hz < low or mean_firing_rate_hz > high:
+        warnings.append(
+            f"mean_firing_rate_hz={mean_firing_rate_hz:.4f} is outside the "
+            f"plausible range [{low}, {high}]"
+        )
+
+    return SufficiencyReport(
+        passes=not failures,
+        n_units=n_units,
+        n_spikes=n_spikes,
+        duration_s=duration_s,
+        mean_firing_rate_hz=mean_firing_rate_hz,
+        n_bins_at_default=n_bins_at_default,
+        warnings=warnings,
+        failures=failures,
+    )

--- a/tests/_fixtures/branching_process.py
+++ b/tests/_fixtures/branching_process.py
@@ -1,0 +1,174 @@
+"""Synthetic ground-truth generators for criticality estimators.
+
+These live under ``tests/`` because they exist only to exercise the metric
+estimators against known truth. :func:`simulate_branching` produces a
+population whose binned activity follows a branching process at a known
+branching ratio ``sigma``; :func:`simulate_poisson_surrogate` produces a
+matched-rate homogeneous-Poisson negative control.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from brain_organoid_criticality.models import SortedSpikes
+
+
+def _activity_to_spikes(
+    activity: np.ndarray,
+    *,
+    n_units: int,
+    bin_size_s: float,
+    rng: np.random.Generator,
+    source_path: Path,
+    metadata: dict[str, object],
+) -> SortedSpikes:
+    """Scatter per-bin population counts onto units as spike times."""
+    n_bins = activity.size
+    total = int(activity.sum())
+    bin_index = np.repeat(np.arange(n_bins), activity)
+    offsets = rng.uniform(0.0, 1.0, size=total)
+    times = (bin_index + offsets) * bin_size_s
+    unit_assignment = rng.integers(1, n_units + 1, size=total)
+
+    unit_ids = np.arange(1, n_units + 1)
+    spike_times_by_unit: dict[int, np.ndarray] = {}
+    for unit_id in unit_ids.tolist():
+        unit_times = np.sort(times[unit_assignment == unit_id])
+        spike_times_by_unit[unit_id] = unit_times
+
+    return SortedSpikes(
+        source_path=source_path,
+        unit_ids=unit_ids,
+        spike_times_by_unit=spike_times_by_unit,
+        t_start_s=0.0,
+        t_stop_s=n_bins * bin_size_s,
+        metadata=metadata,
+    )
+
+
+def simulate_branching(
+    sigma: float,
+    rate_hz: float,
+    duration_s: float,
+    *,
+    seed: int = 0,
+    n_units: int = 30,
+    bin_size_s: float = 0.003,
+    min_lambda: float = 1.0,
+    max_activity_factor: float = 50.0,
+) -> SortedSpikes:
+    """Simulate a branching process with a known branching ratio.
+
+    The population activity ``A`` evolves as ``A[t+1] ~ Poisson(sigma * A[t] +
+    h)`` on a grid of ``bin_size_s`` bins, where the drive ``h = mean *
+    (1 - sigma)`` targets a stationary mean population rate of ``rate_hz``. At
+    criticality (``sigma = 1``) the drive vanishes and the process is a pure
+    martingale; a small ``min_lambda`` floor keeps it from going extinct and a
+    ``max_activity_factor`` ceiling keeps its random walk from running away,
+    neither of which binds for the subcritical cases. The resulting per-bin
+    counts are scattered uniformly across ``n_units`` units as spike times, so
+    that re-binning the flattened population recovers ``A``.
+
+    Parameters
+    ----------
+    sigma : float
+        Target branching ratio in ``(0, 1]``.
+    rate_hz : float
+        Target mean population firing rate (spikes per second, summed over
+        units).
+    duration_s : float
+        Recording duration in seconds.
+    seed : int, optional
+        Seed for the random generator. Default ``0``.
+    n_units : int, optional
+        Number of units to scatter the population activity across.
+        Default ``30``.
+    bin_size_s : float, optional
+        Generation bin size in seconds. Default ``0.003``.
+    min_lambda : float, optional
+        Lower bound on the per-bin Poisson rate, preventing extinction of the
+        critical process. Default ``1.0``.
+    max_activity_factor : float, optional
+        Upper bound on the per-bin Poisson rate as a multiple of the mean
+        activity, bounding the critical random walk. Default ``50.0``.
+
+    Returns
+    -------
+    SortedSpikes
+        Synthetic spikes whose binned population activity has branching ratio
+        ``sigma``.
+    """
+    rng = np.random.default_rng(seed)
+    dt = bin_size_s
+    n_bins = int(round(duration_s / dt))
+    mean_activity = rate_hz * dt
+    drive = mean_activity * (1.0 - sigma)
+    cap = max_activity_factor * mean_activity
+
+    activity = np.empty(n_bins, dtype=np.int64)
+    activity[0] = rng.poisson(mean_activity)
+    for t in range(1, n_bins):
+        rate = min(max(sigma * activity[t - 1] + drive, min_lambda), cap)
+        activity[t] = rng.poisson(rate)
+
+    return _activity_to_spikes(
+        activity,
+        n_units=n_units,
+        bin_size_s=dt,
+        rng=rng,
+        source_path=Path("synthetic-branching.nwb"),
+        metadata={"sigma": sigma, "rate_hz": rate_hz, "bin_size_s": dt},
+    )
+
+
+def simulate_poisson_surrogate(
+    rate_hz: float,
+    duration_s: float,
+    *,
+    seed: int = 0,
+    n_units: int = 30,
+    bin_size_s: float = 0.003,
+) -> SortedSpikes:
+    """Simulate a matched-rate homogeneous-Poisson negative control.
+
+    Per-bin counts are drawn i.i.d. from ``Poisson(rate_hz * bin_size_s)``,
+    so the population activity has no temporal correlation and the branching
+    ratio estimated from it should be near zero.
+
+    Parameters
+    ----------
+    rate_hz : float
+        Mean population firing rate (spikes per second, summed over units).
+    duration_s : float
+        Recording duration in seconds.
+    seed : int, optional
+        Seed for the random generator. Default ``0``.
+    n_units : int, optional
+        Number of units to scatter the population activity across.
+        Default ``30``.
+    bin_size_s : float, optional
+        Generation bin size in seconds. Default ``0.003``.
+
+    Returns
+    -------
+    SortedSpikes
+        Synthetic spikes with i.i.d. per-bin population counts.
+    """
+    rng = np.random.default_rng(seed)
+    dt = bin_size_s
+    n_bins = int(round(duration_s / dt))
+    mean_activity = rate_hz * dt
+
+    activity = rng.poisson(mean_activity, size=n_bins).astype(np.int64)
+
+    return _activity_to_spikes(
+        activity,
+        n_units=n_units,
+        bin_size_s=dt,
+        rng=rng,
+        source_path=Path("synthetic-poisson.nwb"),
+        metadata={"rate_hz": rate_hz, "bin_size_s": dt},
+    )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from brain_organoid_criticality.avalanches import bin_spike_times
+from brain_organoid_criticality.metrics import (
+    branching_ratio,
+    distance_to_criticality,
+)
+from brain_organoid_criticality.models import SortedSpikes, SufficiencyReport
+from brain_organoid_criticality.spikes import flatten_spike_times
+
+from ._fixtures.branching_process import (
+    simulate_branching,
+    simulate_poisson_surrogate,
+)
+
+BIN_SIZE_S = 0.003
+
+
+def _population_counts(spikes: SortedSpikes) -> np.ndarray:
+    flat = flatten_spike_times(spikes)
+    counts, _ = bin_spike_times(
+        flat, BIN_SIZE_S, t_start=spikes.t_start_s, t_stop=spikes.t_stop_s
+    )
+    return counts
+
+
+@pytest.mark.parametrize("sigma", [0.85, 0.95, 0.99, 1.00])
+def test_branching_ratio_recovers_known_sigma(sigma: float) -> None:
+    spikes = simulate_branching(sigma, rate_hz=2000.0, duration_s=120.0, seed=7)
+    counts = _population_counts(spikes)
+
+    est = branching_ratio(counts)
+
+    assert abs(est.sigma - sigma) <= 0.03
+
+
+def test_branching_ratio_poisson_surrogate_is_subcritical() -> None:
+    spikes = simulate_poisson_surrogate(rate_hz=2000.0, duration_s=120.0, seed=7)
+    counts = _population_counts(spikes)
+
+    est = branching_ratio(counts)
+
+    assert est.sigma <= 0.5
+
+
+def test_branching_ratio_populates_estimate_fields() -> None:
+    spikes = simulate_branching(0.95, rate_hz=2000.0, duration_s=60.0, seed=1)
+    counts = _population_counts(spikes)
+
+    est = branching_ratio(counts, k_max=100)
+
+    assert est.k_used.shape == est.r_values.shape
+    assert est.k_used[0] == 1
+    assert est.k_used[-1] == 100
+    assert 0.0 <= est.r_squared <= 1.0
+    assert est.tau_bins > 0.0
+
+
+def test_branching_ratio_rejects_short_series() -> None:
+    with pytest.raises(ValueError):
+        branching_ratio(np.array([1.0, 2.0]))
+
+
+def test_branching_ratio_rejects_zero_variance() -> None:
+    with pytest.raises(ValueError, match="variance"):
+        branching_ratio(np.ones(500))
+
+
+def test_branching_ratio_rejects_unknown_method() -> None:
+    with pytest.raises(ValueError, match="method"):
+        branching_ratio(np.arange(500.0), method="bogus")
+
+
+def test_branching_ratio_rejects_nonpositive_k_max() -> None:
+    with pytest.raises(ValueError, match="k_max"):
+        branching_ratio(np.arange(500.0), k_max=0)
+
+
+def test_distance_to_criticality_returns_dcc_with_ci() -> None:
+    spikes = simulate_branching(0.95, rate_hz=2000.0, duration_s=120.0, seed=3)
+    counts = _population_counts(spikes)
+
+    result = distance_to_criticality(counts, n_bootstrap=200, seed=0)
+
+    assert result.dcc is not None
+    assert result.branching is not None
+    assert abs(result.dcc - 0.05) <= 0.05
+    assert result.ci_lower is not None and result.ci_upper is not None
+    assert result.ci_lower <= result.dcc <= result.ci_upper
+    assert result.bootstrap_n == 200
+
+
+def test_distance_to_criticality_is_reproducible_with_seed() -> None:
+    spikes = simulate_branching(0.95, rate_hz=2000.0, duration_s=60.0, seed=3)
+    counts = _population_counts(spikes)
+
+    first = distance_to_criticality(counts, n_bootstrap=100, seed=42)
+    second = distance_to_criticality(counts, n_bootstrap=100, seed=42)
+
+    assert first.ci_lower == second.ci_lower
+    assert first.ci_upper == second.ci_upper
+
+
+def test_distance_to_criticality_refuses_when_insufficient() -> None:
+    counts = np.random.default_rng(0).poisson(3, size=5000).astype(float)
+    report = SufficiencyReport(
+        passes=False,
+        n_units=2,
+        n_spikes=10,
+        duration_s=1.0,
+        mean_firing_rate_hz=5.0,
+        n_bins_at_default=300,
+        warnings=[],
+        failures=["n_units=2 is below the minimum of 20"],
+    )
+
+    result = distance_to_criticality(counts, n_bootstrap=10, sufficiency=report)
+
+    assert result.dcc is None
+    assert result.ci_lower is None
+    assert result.ci_upper is None
+    assert result.branching is None
+    assert result.sufficiency is report
+    assert result.bootstrap_n == 10

--- a/tests/test_quality.py
+++ b/tests/test_quality.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from brain_organoid_criticality.models import SortedSpikes
+from brain_organoid_criticality.quality import check_sufficiency
+
+
+def _make_spikes(
+    *,
+    n_units: int,
+    duration_s: float,
+    rate_hz: float,
+    seed: int = 0,
+) -> SortedSpikes:
+    """Build a synthetic SortedSpikes with a target per-unit firing rate."""
+    rng = np.random.default_rng(seed)
+    unit_ids = np.arange(1, n_units + 1)
+    spike_times_by_unit: dict[int, np.ndarray] = {}
+    for unit_id in unit_ids.tolist():
+        n_spikes = rng.poisson(rate_hz * duration_s)
+        times = np.sort(rng.uniform(0.0, duration_s, size=n_spikes))
+        spike_times_by_unit[unit_id] = times
+    return SortedSpikes(
+        source_path=Path("synthetic.nwb"),
+        unit_ids=unit_ids,
+        spike_times_by_unit=spike_times_by_unit,
+        t_start_s=0.0,
+        t_stop_s=duration_s,
+    )
+
+
+def test_check_sufficiency_passes_for_adequate_recording() -> None:
+    spikes = _make_spikes(n_units=25, duration_s=120.0, rate_hz=1.0, seed=1)
+
+    report = check_sufficiency(spikes)
+
+    assert report.passes is True
+    assert report.failures == []
+    assert report.n_units == 25
+    assert report.duration_s == 120.0
+    assert report.n_bins_at_default == int(120.0 // 0.003)
+
+
+def test_check_sufficiency_computes_descriptors() -> None:
+    spikes = _make_spikes(n_units=20, duration_s=60.0, rate_hz=2.0, seed=2)
+    total = sum(t.size for t in spikes.spike_times_by_unit.values())
+
+    report = check_sufficiency(spikes)
+
+    assert report.n_units == 20
+    assert report.n_spikes == total
+    assert report.duration_s == 60.0
+    expected_rate = total / (20 * 60.0)
+    assert report.mean_firing_rate_hz == expected_rate
+
+
+def test_check_sufficiency_fails_too_few_units(
+    sorted_spikes_two_units: SortedSpikes,
+) -> None:
+    report = check_sufficiency(sorted_spikes_two_units)
+
+    assert report.passes is False
+    assert any("n_units" in f for f in report.failures)
+    # The failure message names both the observed value and the threshold.
+    assert any("2" in f and "20" in f for f in report.failures)
+
+
+def test_check_sufficiency_fails_too_short_duration() -> None:
+    spikes = _make_spikes(n_units=25, duration_s=10.0, rate_hz=1.0, seed=3)
+
+    report = check_sufficiency(spikes)
+
+    assert report.passes is False
+    assert any("duration" in f for f in report.failures)
+
+
+def test_check_sufficiency_fails_too_few_bins() -> None:
+    # 25 units, 60 s passes units+duration, but a coarse bin size starves bins.
+    spikes = _make_spikes(n_units=25, duration_s=60.0, rate_hz=1.0, seed=4)
+
+    report = check_sufficiency(spikes, bin_size_s=1.0)
+
+    assert report.passes is False
+    assert any("bins" in f.lower() for f in report.failures)
+
+
+def test_check_sufficiency_warns_on_implausible_firing_rate() -> None:
+    # 25 units over 60 s but each firing far above the plausible upper bound.
+    spikes = _make_spikes(n_units=25, duration_s=60.0, rate_hz=500.0, seed=5)
+
+    report = check_sufficiency(spikes)
+
+    assert any("firing_rate" in w for w in report.warnings)
+
+
+def test_check_sufficiency_empty_recording(sorted_spikes_empty: SortedSpikes) -> None:
+    report = check_sufficiency(sorted_spikes_empty)
+
+    assert report.passes is False
+    assert report.n_units == 0
+    assert report.n_spikes == 0
+    assert report.mean_firing_rate_hz == 0.0
+
+
+def test_check_sufficiency_rejects_nonpositive_bin_size(
+    sorted_spikes_two_units: SortedSpikes,
+) -> None:
+    with pytest.raises(ValueError, match="bin_size_s"):
+        check_sufficiency(sorted_spikes_two_units, bin_size_s=0.0)
+
+
+def test_check_sufficiency_thresholds_are_overridable(
+    sorted_spikes_two_units: SortedSpikes,
+) -> None:
+    report = check_sufficiency(
+        sorted_spikes_two_units, min_units=1, min_duration_s=0.5, min_bins_for_bootstrap=1
+    )
+
+    assert report.passes is True
+    assert report.failures == []


### PR DESCRIPTION
Implements the Phase 1 Metric MVP (issue #9): the data-sufficiency check and the MR-estimator distance-to-criticality metric, with synthetic ground-truth generators.

## What's included

**`quality.py` — `check_sufficiency()` → `SufficiencyReport`** (commit 1)
- Computes `n_units`, `n_spikes`, `duration_s`, `mean_firing_rate_hz`, `n_bins_at_default`.
- Unit-count, duration, and bin-count violations become `failures` (block `passes`); an implausible mean firing rate is a `warning` only.
- All thresholds configurable; pinned defaults from `MVP_SPEC.md` §2.2.
- Implements FR-011–FR-013.

**`metrics.py` — branching ratio + DCC** (commit 2)
- `branching_ratio()`: Wilting & Priesemann (2018) multistep-regression estimator. Autoregressive slopes `r(k) = Cov(A_t, A_{t+k}) / Var(A_t)` (computed via FFT) decay as `r(k) = b·σ^k`; σ is recovered from the geometric decay rate, invariant to the subsampling offset `b`.
- `distance_to_criticality()`: `DCC = 1 − σ` with a **moving-block bootstrap** CI that preserves the temporal structure the estimator depends on. Refuses a point estimate (fields `None`) when the supplied `SufficiencyReport` does not pass (FR-028).
- Adds `BranchingRatioEstimate` and `DCCResult` dataclasses.
- Implements FR-016, FR-017, FR-027, FR-028.

**Synthetic ground truth** (`tests/_fixtures/branching_process.py`)
- `simulate_branching()` and `simulate_poisson_surrogate()`. The critical (σ=1) case is a bounded martingale (immigration floor + activity ceiling) so it neither dies nor explodes.

## Verification (NFR-004a falsifiable checks)
- σ recovered within **±0.03** at σ ∈ {0.85, 0.95, 0.99, 1.00}.
- Poisson surrogate yields σ̂ ≤ 0.5.
- Refuses estimate on insufficient data; bootstrap reproducible with a seed.
- **28 tests pass**, **100% coverage** on `metrics.py` and `quality.py`, `ruff` and `mypy` clean.

## Notes
- `verdict` (tri-level) is intentionally **not** added to `SufficiencyReport` — it's a Phase 4 item (PRD §5.3), so YAGNI here.
- The tutorial notebook (#12) and `tests/test_avalanches.py` are separate Phase 1 items, not in this PR.

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)